### PR TITLE
Add Claude Code entries to .gitignore

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,0 @@
-{
-  "permissions": {
-    "allow": ["Read", "Edit", "Write"],
-    "deny": []
-  }
-}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "permissions": {
+    "allow": ["Read", "Edit", "Write"],
+    "deny": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Claude Code
+.claude/worktrees
+.claude/settings.local.json


### PR DESCRIPTION
## What

Adds Claude Code entries to `.gitignore` to exclude generated/local files from version control:

- `.claude/worktrees` — temporary worktree artifacts
- `.claude/settings.local.json` — user-local Claude Code settings

Existing `.gitignore` entries are preserved; only missing pieces are added.